### PR TITLE
Implement textDocument/references MCP tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { ClientCapabilities } from './lsp/types/clientcapabilities/ClientCapabil
 import { MCPTool } from './tools/MCPTool.js';
 import { MCPToolDefinition } from './tools/MCPToolDefinition.js';
 import { MCPToolHover } from './tools/MCPToolHover.js';
+import { MCPToolReferences } from './tools/MCPToolReferences.js';
 import { MCPToolRename } from './tools/MCPToolRename.js';
 import { logger } from './utils/logger.js';
 
@@ -45,6 +46,7 @@ async function main() {
     // Register tools
     toolMap.set('hover', new MCPToolHover(lspManager));
     toolMap.set('definition', new MCPToolDefinition(lspManager));
+    toolMap.set('references', new MCPToolReferences(lspManager));
     toolMap.set('rename', new MCPToolRename(lspManager));
     // MCP server instance
     const mcpServer = new Server(

--- a/src/lsp/LSPManager.ts
+++ b/src/lsp/LSPManager.ts
@@ -4,6 +4,7 @@ import { readFileAsync } from "../utils";
 import { ApplyWorkspaceEditParams, ApplyWorkspaceEditResult } from "./types/ApplyWorkspaceEditParams";
 import { Definition, DefinitionParams } from "./types/DefinitionRequest";
 import { Hover, HoverParams } from "./types/HoverRequest";
+import { References, ReferenceParams } from "./types/ReferencesRequest";
 import { RenameParams } from "./types/RenameRequest";
 import { WorkspaceEdit } from "./types/WorkspaceEdit";
 import { WorkspaceEditApplier } from "./WorkspaceEditApplier";
@@ -53,6 +54,11 @@ export class LSPManager {
   async definition(params: DefinitionParams): Promise<Definition> {
     await this.openDocument(params.textDocument.uri);
     return await this.server.definition(params);
+  }
+
+  async references(params: ReferenceParams): Promise<References> {
+    await this.openDocument(params.textDocument.uri);
+    return await this.server.references(params);
   }
 
   async rename(params: RenameParams): Promise<WorkspaceEdit | null> {

--- a/src/lsp/LSPServerEx.ts
+++ b/src/lsp/LSPServerEx.ts
@@ -5,6 +5,7 @@ import { DidOpenTextDocumentParams } from "./types/DidOpenTextDocument";
 import { Hover, HoverParams } from "./types/HoverRequest";
 import { InitializeParams } from "./types/Initialize";
 import { InitializedParams } from "./types/Initialized";
+import { References, ReferenceParams } from "./types/ReferencesRequest";
 import { RenameParams } from "./types/RenameRequest";
 import { ResponseMessage } from "./types/ResponseMessage";
 import { WorkspaceEdit } from "./types/WorkspaceEdit";
@@ -16,6 +17,7 @@ export interface LSPServerEx {
   didClose(params: DidCloseTextDocumentParams): Promise<void>;
   hover(params: HoverParams): Promise<Hover | null>;
   definition(params: DefinitionParams): Promise<Definition>;
+  references(params: ReferenceParams): Promise<References>;
   rename(params: RenameParams): Promise<WorkspaceEdit | null>;
   applyEdit(params: ApplyWorkspaceEditParams): Promise<ApplyWorkspaceEditResult>;
 }

--- a/src/lsp/LSPServerExImpl.ts
+++ b/src/lsp/LSPServerExImpl.ts
@@ -7,6 +7,7 @@ import { DidOpenTextDocumentParams } from "./types/DidOpenTextDocument";
 import { Hover, HoverParams, HoverT } from "./types/HoverRequest";
 import { InitializeParams } from "./types/Initialize";
 import { InitializedParams } from "./types/Initialized";
+import { References, ReferenceParams, ReferencesT } from "./types/ReferencesRequest";
 import { RenameParams } from "./types/RenameRequest";
 import { ResponseMessage } from "./types/ResponseMessage";
 import { WorkspaceEdit, WorkspaceEditT } from "./types/WorkspaceEdit";
@@ -47,6 +48,17 @@ export class LSPServerExImpl implements LSPServerEx {
     const result = await this.server.sendRequest('textDocument/definition', params);
     logger.debug("[LSP] Definition request completed with result:", result);
     if (DefinitionT.is(result.result)) {
+      return result.result;
+    } else {
+      return null;
+    }
+  }
+
+  async references(params: ReferenceParams): Promise<References> {
+    logger.debug("[LSP] Requesting references with params:", params);
+    const result = await this.server.sendRequest('textDocument/references', params);
+    logger.debug("[LSP] References request completed with result:", result);
+    if (ReferencesT.is(result.result)) {
       return result.result;
     } else {
       return null;

--- a/src/lsp/types/ReferencesRequest.ts
+++ b/src/lsp/types/ReferencesRequest.ts
@@ -1,0 +1,55 @@
+import * as t from "io-ts";
+
+import { Location, LocationT } from "./Location";
+import { TextDocumentRegistrationOptions } from "./Register";
+import { TextDocumentPositionParams, TextDocumentPositionParamsT } from "./TextDocumentPositionParams";
+import { WorkDoneProgressOptions } from "./WorkDoneProgressOptions";
+import { WorkDoneProgressParams, WorkDoneProgressParamsT } from "./WorkDoneProgressParams";
+
+/**
+ * Client Capability:
+ * - property name (optional): textDocument.references
+ * - property type: ReferenceClientCapabilities defined as follows:
+ */
+export interface ReferenceClientCapabilities {
+  /**
+   * Whether references supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+}
+
+export type ReferenceOptions = WorkDoneProgressOptions;
+
+export interface ReferenceRegistrationOptions
+  extends TextDocumentRegistrationOptions, ReferenceOptions {
+}
+
+export interface ReferenceContext {
+  /**
+   * Include the declaration of the current symbol.
+   */
+  includeDeclaration: boolean;
+}
+
+export const ReferenceContextT = t.type({
+  includeDeclaration: t.boolean,
+});
+
+export interface ReferenceParams extends TextDocumentPositionParams, WorkDoneProgressParams {
+  context: ReferenceContext;
+}
+
+export const ReferenceParamsT = t.intersection([
+  TextDocumentPositionParamsT,
+  WorkDoneProgressParamsT,
+  t.type({
+    context: ReferenceContextT,
+  }),
+]);
+
+/**
+ * The result of a references request.
+ */
+export type References = Location[] | null;
+
+export const ReferencesT = t.union([t.array(LocationT), t.null]);

--- a/src/tools/MCPToolDefinition.test.ts
+++ b/src/tools/MCPToolDefinition.test.ts
@@ -25,6 +25,7 @@ describe('MCPToolDefinition', () => {
       didClose: jest.fn().mockResolvedValue(undefined),
       hover: jest.fn(),
       definition: definitionSpy,
+      references: jest.fn(),
       rename: jest.fn(),
       applyEdit: jest.fn(),
     };

--- a/src/tools/MCPToolHover.test.ts
+++ b/src/tools/MCPToolHover.test.ts
@@ -27,6 +27,7 @@ describe('MCPToolHover', () => {
       didClose: jest.fn().mockResolvedValue(undefined),
       hover: hoverSpy,
       definition: jest.fn(),
+      references: jest.fn(),
       rename: jest.fn(),
       applyEdit: jest.fn(),
     };

--- a/src/tools/MCPToolReferences.test.ts
+++ b/src/tools/MCPToolReferences.test.ts
@@ -1,0 +1,243 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+
+import { MCPToolReferences } from './MCPToolReferences';
+import { LSPManager } from '../lsp/LSPManager';
+import { LSPServerEx } from '../lsp/LSPServerEx';
+import { Location } from '../lsp/types/Location';
+
+// Mock the readFileAsync function
+jest.mock('../utils', () => ({
+  readFileAsync: jest.fn().mockResolvedValue('mock file content'),
+}));
+
+describe('MCPToolReferences', () => {
+  let mockLSPServerEx: jest.Mocked<LSPServerEx>;
+  let lspManager: LSPManager;
+  let mcpToolReferences: MCPToolReferences;
+  let referencesSpy: jest.MockedFunction<LSPServerEx['references']>;
+
+  beforeEach(() => {
+    referencesSpy = jest.fn();
+    mockLSPServerEx = {
+      initialize: jest.fn(),
+      initialized: jest.fn(),
+      didOpen: jest.fn().mockResolvedValue(undefined),
+      didClose: jest.fn().mockResolvedValue(undefined),
+      hover: jest.fn(),
+      definition: jest.fn(),
+      references: referencesSpy,
+      rename: jest.fn(),
+      applyEdit: jest.fn(),
+    };
+    lspManager = new LSPManager(mockLSPServerEx);
+    mcpToolReferences = new MCPToolReferences(lspManager);
+  });
+
+  describe('listItem', () => {
+    it('should return the correct tool description', () => {
+      const tool = mcpToolReferences.listItem();
+
+      expect(tool.name).toBe('references');
+      expect(tool.description).toBe('Get all references to a symbol at a specific position in a TypeScript file');
+      expect(tool.inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          uri: {
+            type: 'string',
+            description: 'File URI (e.g., file:///path/to/file.ts)',
+          },
+          line: {
+            type: 'number',
+            description: 'Line number (0-based)',
+          },
+          character: {
+            type: 'number',
+            description: 'Character position (0-based)',
+          },
+          includeDeclaration: {
+            type: 'boolean',
+            description: 'Whether to include the symbol declaration in the results (defaults to true)',
+          },
+        },
+        required: ['uri', 'line', 'character'],
+      });
+    });
+  });
+
+  describe('handle', () => {
+    const validParams = {
+      uri: 'file:///test.ts',
+      line: 10,
+      character: 5,
+    };
+
+    it('should return references for multiple results', async () => {
+      const mockReferences: Location[] = [
+        {
+          uri: 'file:///src/test1.ts',
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+        },
+        {
+          uri: 'file:///src/test2.ts',
+          range: {
+            start: { line: 5, character: 2 },
+            end: { line: 5, character: 2 },
+          },
+        },
+      ];
+      referencesSpy.mockResolvedValue(mockReferences);
+
+      const result = await mcpToolReferences.handle(validParams);
+
+      expect(referencesSpy).toHaveBeenCalledWith({
+        textDocument: { uri: 'file:///test.ts' },
+        position: { line: 10, character: 5 },
+        context: { includeDeclaration: true },
+      });
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0]).toEqual({
+        type: 'text',
+        text: 'Reference 1: /src/test1.ts:1:1',
+      });
+      expect(result.content[1]).toEqual({
+        type: 'text',
+        text: 'Reference 2: /src/test2.ts:6:3',
+      });
+    });
+
+    it('should handle includeDeclaration parameter', async () => {
+      const mockReferences: Location[] = [
+        {
+          uri: 'file:///src/test.ts',
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+        },
+      ];
+      referencesSpy.mockResolvedValue(mockReferences);
+
+      const paramsWithDeclaration = {
+        ...validParams,
+        includeDeclaration: false,
+      };
+
+      const result = await mcpToolReferences.handle(paramsWithDeclaration);
+
+      expect(referencesSpy).toHaveBeenCalledWith({
+        textDocument: { uri: 'file:///test.ts' },
+        position: { line: 10, character: 5 },
+        context: { includeDeclaration: false },
+      });
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({
+        type: 'text',
+        text: 'Reference 1: /src/test.ts:1:1',
+      });
+    });
+
+    it('should default includeDeclaration to true', async () => {
+      const mockReferences: Location[] = [
+        {
+          uri: 'file:///src/test.ts',
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+        },
+      ];
+      referencesSpy.mockResolvedValue(mockReferences);
+
+      await mcpToolReferences.handle(validParams);
+
+      expect(referencesSpy).toHaveBeenCalledWith({
+        textDocument: { uri: 'file:///test.ts' },
+        position: { line: 10, character: 5 },
+        context: { includeDeclaration: true },
+      });
+    });
+
+    it('should return "No references found" for null result', async () => {
+      referencesSpy.mockResolvedValue(null);
+
+      const result = await mcpToolReferences.handle(validParams);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({
+        type: 'text',
+        text: 'No references found.',
+      });
+    });
+
+    it('should return "No references found" for empty array result', async () => {
+      referencesSpy.mockResolvedValue([]);
+
+      const result = await mcpToolReferences.handle(validParams);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({
+        type: 'text',
+        text: 'No references found.',
+      });
+    });
+
+    it('should throw McpError for invalid parameters', async () => {
+      const invalidParams = {
+        uri: 'file:///test.ts',
+        // missing line and character
+      };
+
+      await expect(mcpToolReferences.handle(invalidParams)).rejects.toThrow(McpError);
+    });
+
+    it('should throw McpError when LSP request fails', async () => {
+      referencesSpy.mockRejectedValue(new Error('LSP error'));
+
+      await expect(mcpToolReferences.handle(validParams)).rejects.toThrow(McpError);
+    });
+
+    it('should format range correctly when start and end are different', async () => {
+      const mockReferences: Location[] = [
+        {
+          uri: 'file:///src/test.ts',
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 2, character: 5 },
+          },
+        },
+      ];
+      referencesSpy.mockResolvedValue(mockReferences);
+
+      const result = await mcpToolReferences.handle(validParams);
+
+      expect(result.content[0]).toEqual({
+        type: 'text',
+        text: 'Reference 1: /src/test.ts:1:1 to 3:6',
+      });
+    });
+
+    it('should handle single reference result', async () => {
+      const mockReferences: Location[] = [
+        {
+          uri: 'file:///src/test.ts',
+          range: {
+            start: { line: 10, character: 5 },
+            end: { line: 10, character: 15 },
+          },
+        },
+      ];
+      referencesSpy.mockResolvedValue(mockReferences);
+
+      const result = await mcpToolReferences.handle(validParams);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0]).toEqual({
+        type: 'text',
+        text: 'Reference 1: /src/test.ts:11:6 to 11:16',
+      });
+    });
+  });
+});

--- a/src/tools/MCPToolReferences.ts
+++ b/src/tools/MCPToolReferences.ts
@@ -1,0 +1,128 @@
+import {
+  ErrorCode,
+  McpError,
+  type CallToolRequest,
+  type CallToolResult,
+  type TextContent,
+  type Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import * as t from "io-ts";
+
+import { MCPTool } from "./MCPTool";
+import { LSPManager } from "../lsp/LSPManager";
+import { Location } from "../lsp/types/Location";
+import { References } from "../lsp/types/ReferencesRequest";
+
+export class MCPToolReferences implements MCPTool {
+  constructor(private manager: LSPManager) {}
+
+  listItem(): Tool {
+    return listItemReferences();
+  }
+
+  async handle(params: CallToolRequest["params"]["arguments"]): Promise<CallToolResult> {
+    return handleReferences(this.manager, params);
+  }
+}
+
+function listItemReferences(): Tool {
+  return {
+    name: 'references',
+    description: 'Get all references to a symbol at a specific position in a TypeScript file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        uri: {
+          type: 'string',
+          description: 'File URI (e.g., file:///path/to/file.ts)',
+        },
+        line: {
+          type: 'number',
+          description: 'Line number (0-based)',
+        },
+        character: {
+          type: 'number',
+          description: 'Character position (0-based)',
+        },
+        includeDeclaration: {
+          type: 'boolean',
+          description: 'Whether to include the symbol declaration in the results (defaults to true)',
+        },
+      },
+      required: ['uri', 'line', 'character'],
+    },
+  };
+}
+
+const ReferencesParamsT = t.intersection([
+  t.type({
+    uri: t.string,
+    line: t.number,
+    character: t.number,
+  }),
+  t.partial({
+    includeDeclaration: t.boolean,
+  }),
+]);
+
+async function handleReferences(
+  manager: LSPManager,
+  params: CallToolRequest["params"]["arguments"],
+): Promise<CallToolResult> {
+  const decoded = ReferencesParamsT.decode(params);
+  if (decoded._tag === 'Left') {
+    throw new McpError(ErrorCode.InvalidParams, `Invalid parameters for references tool: ${JSON.stringify(decoded.left)}`);
+  }
+  const { uri, line, character, includeDeclaration = true } = decoded.right;
+  try {
+    const result = await manager.references({
+      textDocument: { uri },
+      position: { line, character },
+      context: { includeDeclaration },
+    });
+    return result !== null
+      ? referencesToCallToolResult(result)
+      : referencesNothingContent();
+  } catch (error) {
+    throw new McpError(ErrorCode.InternalError, `Failed to get references information: ${String(error)}`);
+  }
+}
+
+function referencesToCallToolResult(references: References): CallToolResult {
+  return {
+    content: referencesToTextContents(references),
+  };
+}
+
+function referencesToTextContents(references: References): TextContent[] {
+  if (references === null || references.length === 0) {
+    return [{
+      type: 'text',
+      text: 'No references found.',
+    }];
+  }
+  return references.map((location, index) => ({
+    type: 'text',
+    text: `Reference ${index + 1}: ${locationToString(location)}`,
+  }));
+}
+
+function locationToString(location: Location): string {
+  const filePath = location.uri.replace('file://', '');
+  const start = location.range.start;
+  const end = location.range.end;
+  const startPos = `${start.line + 1}:${start.character + 1}`;
+  if (start.line !== end.line || start.character !== end.character) {
+    return `${filePath}:${startPos} to ${end.line + 1}:${end.character + 1}`;
+  }
+  return `${filePath}:${startPos}`;
+}
+
+function referencesNothingContent(): CallToolResult {
+  return {
+    content: [{
+      type: 'text',
+      text: 'No references found.',
+    }],
+  };
+}

--- a/src/tools/MCPToolRename.test.ts
+++ b/src/tools/MCPToolRename.test.ts
@@ -35,6 +35,7 @@ describe('MCPToolRename', () => {
       didClose: jest.fn().mockResolvedValue(undefined),
       hover: jest.fn(),
       definition: jest.fn(),
+      references: jest.fn(),
       rename: renameSpy,
       applyEdit: jest.fn(),
     };


### PR DESCRIPTION
## Summary
- Implement comprehensive textDocument/references support for the MCP-LSP server
- Add LSP types and infrastructure for references functionality
- Create MCPToolReferences with includeDeclaration parameter support
- Add comprehensive test suite with 10 test cases covering all scenarios

## Test plan
- [x] All tests pass (82/82 total)
- [x] Linting passes with no errors
- [x] Build compiles successfully
- [x] Manual testing shows correct reference finding across codebase
- [x] includeDeclaration parameter works correctly (tested with true/false)
- [x] Integration with TypeScript Language Server verified

## Changes
- **New files**: ReferencesRequest.ts, MCPToolReferences.ts, MCPToolReferences.test.ts
- **Updated LSP infrastructure**: LSPManager, LSPServerEx, LSPServerExImpl
- **Tool registration**: Added references tool to MCP server
- **Test updates**: Updated existing test mocks to include references method

Resolves #3